### PR TITLE
simplified calls to pull iterable dict keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 sys*
 wx*
 wx.html*
+
+*.pyc
+
+.coverage

--- a/kiki.py
+++ b/kiki.py
@@ -457,7 +457,7 @@ class MyFrameWithEvents(MyFrame):
         # STEP 1: try to compile the regex
         # get flags to use in the compilation
         flags = 0
-        for flag in list(self.flagmapper.keys()):
+        for flag in self.flagmapper:
             if self.flagmapper[flag].IsChecked():
                 flags = flags|eval(flag)
         # compile the regex and stop with error message if invalid
@@ -652,7 +652,7 @@ class MyFrameWithEvents(MyFrame):
         self.RegexBox.SetValue(settings.get(REGEX, ""))
 
         # load the flags and desired type of re functionality
-        for flag in list(self.flagmapper.keys()):
+        for flag in self.flagmapper:
             self.flagmapper[flag].SetValue(settings.get(flag, False))
         self.MethodBox.SetSelection(settings.get(SEARCHTYPE, 0))
 
@@ -675,7 +675,7 @@ class MyFrameWithEvents(MyFrame):
         settings.set(REGEX, self.RegexBox.GetValue())
 
         # save the selected flags
-        for flag in list(self.flagmapper.keys()):
+        for flag in self.flagmapper:
             settings.set(flag, self.flagmapper[flag].GetValue())
         settings.set(SEARCHTYPE, self.MethodBox.GetSelection())
 


### PR DESCRIPTION
The default 2to3 conversion is overly cautious in converting
attempts to grab a dictionary's list of keys.  If we want to
iterate over the keys (rather than just have access to them
as a list), then we can follow the advice on this conversion
page to be compatible in both 2 and 3 by removing both the
call to list() and .keys():

http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items